### PR TITLE
Upgrade nom from 6 => 7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde-alloc = ["alloc", "serde/alloc"]
 serde-std = ["std", "serde/std"]
 
 [dependencies]
-nom = { version = "6", default-features = false }
+nom = { version = "7", default-features = false }
 serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/src/parser/details.rs
+++ b/src/parser/details.rs
@@ -25,10 +25,10 @@ use crate::{
 fn many_m_n_count<I, O, E, F>(m: usize, n: usize, f: F) -> impl nom::Parser<I, usize, E>
 where
     F: nom::Parser<I, O, E>,
-    I: Clone + PartialEq,
+    I: Clone + PartialEq + nom::InputLength,
     E: ParseError<I>,
 {
-    fold_many_m_n(m, n, f, 0, |count, _| count + 1)
+    fold_many_m_n(m, n, f, || 0, |count, _| count + 1)
 }
 
 /// Parses RFC 3986 / 3987 IRI.


### PR DESCRIPTION
This is mainly to avoid the messed up funty/bitvec situation. https://github.com/myrrlyn/funty/issues/3