### PR TITLE
fix: make `UriTemplateStr` repr transparent

### DIFF
--- a/src/template/string.rs
+++ b/src/template/string.rs
@@ -82,6 +82,7 @@ mod owned;
 /// ```
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
+#[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UriTemplateStr {
     /// The raw string.


### PR DESCRIPTION
The comments in the code imply that `UriTemplateStr` should have a transparent data layout, but the struct definition doesn't have the `#[repr(transparent)]` attribute. 