### PR TITLE
Use the correct validator for post fragment update assertions

### DIFF
--- a/src/types/generic/reference.rs
+++ b/src/types/generic/reference.rs
@@ -591,7 +591,7 @@ impl<S: Spec> RiReferenceString<S> {
     /// Removes fragment part (and following `#` character) if `None` is given.
     pub fn set_fragment(&mut self, fragment: Option<&RiFragmentStr<S>>) {
         raw::set_fragment(&mut self.inner, fragment.map(AsRef::as_ref));
-        debug_assert!(iri::<S>(&self.inner).is_ok());
+        debug_assert!(iri_reference::<S>(&self.inner).is_ok());
     }
 
     /// Removes the password completely (including separator colon) from `self` even if it is empty.

--- a/src/types/generic/relative.rs
+++ b/src/types/generic/relative.rs
@@ -14,7 +14,6 @@ use crate::spec::Spec;
 use crate::types::RiReferenceString;
 use crate::types::{RiAbsoluteStr, RiFragmentStr, RiQueryStr, RiReferenceStr, RiStr};
 #[cfg(feature = "alloc")]
-use crate::validate::iri;
 use crate::validate::relative_ref;
 
 define_custom_string_slice! {
@@ -422,7 +421,7 @@ impl<S: Spec> RiRelativeString<S> {
     /// Removes fragment part (and following `#` character) if `None` is given.
     pub fn set_fragment(&mut self, fragment: Option<&RiFragmentStr<S>>) {
         raw::set_fragment(&mut self.inner, fragment.map(AsRef::as_ref));
-        debug_assert!(iri::<S>(&self.inner).is_ok());
+        debug_assert!(relative_ref::<S>(&self.inner).is_ok());
     }
 
     /// Removes the password completely (including separator colon) from `self` even if it is empty.


### PR DESCRIPTION
This fixes a small bug that is present in debug builds where `set_fragment()` will universally fail for `RiRelativeString` and often for `RiReferenceString`. This was due to the fact that validation was happening using a "normal" IRI validator.